### PR TITLE
feat: 네이버 지역 검색 API 기반 장소(맛집) 검색 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+JjimKong 백엔드. 소셜 로그인(OAuth2) 기반으로 사용자가 맛집(Post)을 저장·리뷰하고 그룹으로 공유하는 서비스의 Spring Boot REST API 서버.
+
+## 기술 스택
+
+- **Java 17**, **Spring Boot 3.5.6** (Gradle, `build.gradle`)
+- **Spring Data JPA** + Hibernate, DB는 MySQL(운영) / H2(로컬·테스트)
+- **Spring Security + OAuth2 Client** — Google / Kakao / Naver 소셜 로그인
+- **JWT** (`com.auth0:java-jwt`) — AccessToken / RefreshToken
+- **Redis** (`spring-boot-starter-data-redis`) — RefreshToken 등 토큰 저장
+- **SpringDoc OpenAPI (Swagger)** — `/swagger-ui.html`
+- **Lombok**, Bean Validation
+
+## 빌드 & 실행
+
+PowerShell 환경(Windows) 기준:
+
+```powershell
+.\gradlew.bat build          # 빌드
+.\gradlew.bat test           # 전체 테스트
+.\gradlew.bat bootRun        # 로컬 실행
+.\gradlew.bat test --tests "com.jjimkong_backend.SomeTest"   # 단일 테스트
+```
+
+> `src/main/resources`는 `.gitignore`에 포함되어 추적되지 않는다. `application.yml`(DB·OAuth·Redis·JWT 시크릿)은 로컬에만 존재하므로 새 환경에서는 직접 준비해야 한다. `processResources { expand(project.properties) }` 설정이 있어 리소스 내 `${...}` 플레이스홀더가 Gradle 프로퍼티로 치환된다.
+
+## 패키지 구조
+
+기능을 **레이어 우선**으로 나누고, 그 안에서 **도메인별**로 다시 나눈다.
+
+```
+com.jjimkong_backend
+├── api
+│   ├── controller/<도메인>/XxxControllerV1.java   # REST 엔드포인트
+│   └── service/<도메인>/
+│       ├── XxxService.java                        # 인터페이스
+│       ├── impl/XxxServiceImpl.java               # 구현체
+│       └── dto/request|response/                  # 요청·응답 DTO (record)
+├── domain/<도메인>/
+│   ├── entity/                                    # JPA 엔티티, Enum
+│   └── repository/                                # Spring Data JPA 레포지토리
+└── global
+    ├── config/                                    # security, jwt, oauth2, redis, cookie, cors
+    └── response/
+        ├── api/ApiResponse.java                   # 공통 성공 응답
+        └── exception/                             # 예외 처리 일체
+```
+
+도메인: `users`, `posts`, `reviews`, `groups`, `favorites`. (DTO는 `domain`이 아니라 `api.service.<도메인>.dto` 아래에 둔다.)
+
+## 핵심 규약 (새 기능 추가 시 따를 것)
+
+### 1. 레이어 흐름
+`Controller → Service(interface) → ServiceImpl → Repository`. 컨트롤러는 검증·위임만, 비즈니스 로직은 ServiceImpl에 둔다. 서비스는 항상 **인터페이스 + `impl` 구현체** 쌍으로 만든다.
+
+### 2. 컨트롤러
+- 클래스명은 `XxxControllerV1`, 매핑은 `/api/v1/<복수형>` (예: `/api/v1/posts`).
+- `@RestController @RequiredArgsConstructor @RequestMapping(...) @Slf4j`.
+- 인증된 사용자는 `@AuthenticationPrincipal CustomOAuth2User customOAuth2User`로 받고 `customOAuth2User.getUser()`로 `User` 획득.
+- 메서드 진입 시 `log.info("XxxController.method - userId: {}", ...)` 로깅.
+- 반환 타입은 항상 `ApiResponse<T>`. 각 메서드 위에 한 줄 설명 + HTTP 메서드/경로 Javadoc 주석을 단다.
+
+### 3. 응답 — `ApiResponse<T>`
+직접 `new` 하지 말고 정적 팩토리만 사용:
+- 조회·수정 성공: `ApiResponse.ok(data)`
+- 생성: `ApiResponse.created(data)`
+- 본문 없는 삭제 등: `ApiResponse.noContent()`
+
+### 4. DTO
+- `request` / `response` 모두 **Java `record`**.
+- 요청 DTO는 엔티티 변환 메서드 `toEntity(...)`를 가진다.
+- 응답 DTO는 정적 팩토리 `from(Entity)`로 만든다. 엔티티를 컨트롤러 밖으로 직접 노출하지 않는다.
+
+### 5. 엔티티
+- `BaseEntity` 상속 → `createdAt`, `updatedAt`(Hibernate `@CreationTimestamp`/`@UpdateTimestamp`), `status`(`Status` Enum, 기본 `ACTIVE`) 자동 포함.
+- `@NoArgsConstructor(access = AccessLevel.PROTECTED)` + 필요한 필드만 받는 명시적 생성자(또는 `@Builder`). Setter 금지.
+- 값 변경은 의미 있는 메서드로 노출: `update(...)`, `delete()`(소프트 삭제 — `status = DELETED`) 등.
+- 테이블·컬럼명은 `@Table(name=...)`, `@Column(name=...)`로 스네이크 케이스 명시. PK는 `IDENTITY` 전략에 `<도메인>_id`.
+- Enum 필드는 `@Enumerated(EnumType.STRING)`. 연관관계는 `@ManyToOne(fetch = FetchType.LAZY)` 기본.
+- 소프트 삭제 필터: `User`에 `@FilterDef/@Filter("activeFilter")`가 있고 `UserRepositoryImpl.enableActiveFilter()`로 활성화한다.
+
+### 6. 레포지토리
+- 기본은 `JpaRepository<Entity, Long>` 확장, 쿼리 메서드(`findByUser` 등) 활용.
+- 커스텀 동작이 필요하면 `XxxRepositoryCustom` 인터페이스 + `impl/XxxRepositoryImpl`(EntityManager 직접 사용) 패턴.
+
+### 7. 예외 처리
+- 비즈니스 예외는 `throw new BadRequestException(ExceptionCode.XXX)` 형태. (`CustomException` 하위: `BadRequestException`, `AuthenticationException`, `RedisException`)
+- 새 에러는 **반드시 `ExceptionCode` Enum에 추가** — `(code, HttpStatus, 한글 메시지)`. 코드 규칙 예: `E_PST_001`(Post 관련). 메시지는 한국어.
+- 전역 처리는 `GlobalExceptionHandler`(`@RestControllerAdvice`)가 담당. 컨트롤러에서 try-catch 하지 않는다.
+- 권한 검증 패턴: 소유자 비교 후 불일치 시 `NO_PERMISSION_TO_*` 예외 (예: `PostServiceImpl.updatePost`).
+
+### 8. 트랜잭션
+- `ServiceImpl`에 클래스 레벨 `@Transactional(readOnly = true)`, 쓰기 메서드에만 `@Transactional` 오버라이드.
+
+### 9. 인증/보안
+- 세션 STATELESS, OAuth2 로그인 성공 시 `OAuth2LoginSuccessHandler`에서 JWT 발급.
+- `JwtAuthFilter`가 `UsernamePasswordAuthenticationFilter` 앞에서 토큰 검증.
+- 공개 엔드포인트는 `SecurityConfig`의 `authorizeHttpRequests`에 추가(예: swagger, reissue). 그 외 기본 `authenticated()`.
+- 신규 OAuth2 공급자는 `global/config/oauth2/userinfo/`에 `OAuth2UserInfo` 구현 추가.
+
+## 컨벤션 요약
+
+- 패키지·클래스는 영어, 로그·예외 메시지·주석은 한국어 혼용(기존 스타일 유지).
+- 커밋 메시지: `feat : ...`, `feat: ...` 등 한국어 설명 (기존 히스토리 참고). 이슈/PR 템플릿은 `.github/` 참고.
+- 새 기능은 위 5개 레이어(controller / service / impl / dto / entity·repository)를 모두 채우고, 응답은 `ApiResponse`, 에러는 `ExceptionCode`로 일관되게 처리할 것.

--- a/src/main/java/com/jjimkong_backend/api/controller/map/MapControllerV1.java
+++ b/src/main/java/com/jjimkong_backend/api/controller/map/MapControllerV1.java
@@ -1,0 +1,39 @@
+package com.jjimkong_backend.api.controller.map;
+
+import com.jjimkong_backend.api.service.map.MapService;
+import com.jjimkong_backend.api.service.map.dto.request.PlaceSearchRequest;
+import com.jjimkong_backend.api.service.map.dto.response.PlaceSearchResponse;
+import com.jjimkong_backend.global.config.oauth2.CustomOAuth2User;
+import com.jjimkong_backend.global.response.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/maps")
+@RequiredArgsConstructor
+@Slf4j
+public class MapControllerV1 {
+
+    private final MapService mapService;
+
+    /**
+     * ✅ 장소(맛집) 키워드 검색
+     * GET /api/v1/maps/places
+     */
+    @GetMapping("/places")
+    public ApiResponse<PlaceSearchResponse> searchPlaces(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @Valid @ModelAttribute PlaceSearchRequest request) {
+        log.info("MapControllerV1.searchPlaces - userId: {}, query: {}",
+                customOAuth2User.getUser().getId(), request.query());
+
+        PlaceSearchResponse response = mapService.searchPlaces(request);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/jjimkong_backend/api/service/map/MapService.java
+++ b/src/main/java/com/jjimkong_backend/api/service/map/MapService.java
@@ -1,0 +1,12 @@
+package com.jjimkong_backend.api.service.map;
+
+import com.jjimkong_backend.api.service.map.dto.request.PlaceSearchRequest;
+import com.jjimkong_backend.api.service.map.dto.response.PlaceSearchResponse;
+
+public interface MapService {
+
+    /**
+     * 네이버 지역 검색 API로 장소(맛집)를 키워드 검색한다.
+     */
+    PlaceSearchResponse searchPlaces(PlaceSearchRequest request);
+}

--- a/src/main/java/com/jjimkong_backend/api/service/map/dto/request/PlaceSearchRequest.java
+++ b/src/main/java/com/jjimkong_backend/api/service/map/dto/request/PlaceSearchRequest.java
@@ -1,0 +1,37 @@
+package com.jjimkong_backend.api.service.map.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 장소(맛집) 키워드 검색 요청.
+ * <p>
+ * GET 쿼리 파라미터로 바인딩된다. (예: {@code ?query=강남 맛집&display=5&sort=random})
+ *
+ * @param query   검색어 (필수)
+ * @param display 검색 결과 개수 (1~5, 기본 5)
+ * @param sort    정렬 방식 (random: 정확도순, comment: 리뷰 많은 순. 기본 random)
+ */
+public record PlaceSearchRequest(
+        @NotBlank(message = "검색어를 입력해 주세요.")
+        String query,
+
+        @Min(value = 1, message = "검색 결과 개수는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "검색 결과 개수는 최대 5개입니다.")
+        Integer display,
+
+        String sort
+) {
+
+    private static final int DEFAULT_DISPLAY = 5;
+    private static final String DEFAULT_SORT = "random";
+
+    public int displayOrDefault() {
+        return display != null ? display : DEFAULT_DISPLAY;
+    }
+
+    public String sortOrDefault() {
+        return (sort != null && !sort.isBlank()) ? sort : DEFAULT_SORT;
+    }
+}

--- a/src/main/java/com/jjimkong_backend/api/service/map/dto/response/PlaceSearchResponse.java
+++ b/src/main/java/com/jjimkong_backend/api/service/map/dto/response/PlaceSearchResponse.java
@@ -1,0 +1,109 @@
+package com.jjimkong_backend.api.service.map.dto.response;
+
+import java.util.List;
+
+/**
+ * 장소(맛집) 키워드 검색 응답.
+ * <p>
+ * 클라이언트에 노출하는 응답({@link PlaceSearchResponse}, {@link PlaceItem})과
+ * 네이버 지역 검색 API의 원본 응답({@link NaverLocalSearchResult})을 한곳에 모아 둔다.
+ * 원본 응답은 내부 변환용이며 컨트롤러 밖으로 직접 노출하지 않는다.
+ *
+ * @param total   전체 검색 결과 수
+ * @param display 실제 반환된 결과 수
+ * @param items   장소 목록
+ */
+public record PlaceSearchResponse(
+        int total,
+        int display,
+        List<PlaceItem> items
+) {
+
+    public static PlaceSearchResponse from(NaverLocalSearchResult result) {
+        List<PlaceItem> items = (result.items() == null)
+                ? List.of()
+                : result.items().stream().map(PlaceItem::from).toList();
+        return new PlaceSearchResponse(result.total(), result.display(), items);
+    }
+
+    /**
+     * 클라이언트에 노출하는 개별 장소 정보.
+     *
+     * @param title       장소명 (HTML 태그 제거됨)
+     * @param category    업종 분류
+     * @param description 설명
+     * @param telephone   전화번호
+     * @param address     지번 주소
+     * @param roadAddress 도로명 주소
+     * @param longitude   경도(WGS84)
+     * @param latitude    위도(WGS84)
+     */
+    public record PlaceItem(
+            String title,
+            String category,
+            String description,
+            String telephone,
+            String address,
+            String roadAddress,
+            Double longitude,
+            Double latitude
+    ) {
+
+        // 네이버 지역 검색의 mapx/mapy는 WGS84 좌표에 10^7을 곱한 정수 문자열로 내려온다.
+        private static final double COORDINATE_DIVISOR = 1e7;
+
+        public static PlaceItem from(NaverLocalSearchResult.Item item) {
+            return new PlaceItem(
+                    removeHtmlTags(item.title()),
+                    item.category(),
+                    removeHtmlTags(item.description()),
+                    item.telephone(),
+                    item.address(),
+                    item.roadAddress(),
+                    parseCoordinate(item.mapx()),
+                    parseCoordinate(item.mapy())
+            );
+        }
+
+        private static String removeHtmlTags(String value) {
+            return value == null ? null : value.replaceAll("<[^>]+>", "");
+        }
+
+        private static Double parseCoordinate(String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            try {
+                return Long.parseLong(value.trim()) / COORDINATE_DIVISOR;
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * 네이버 지역 검색 API의 원본 응답(raw)을 매핑하는 내부 DTO.
+     * <p>
+     * Jackson이 알 수 없는 필드(lastBuildDate 등)는 무시한다(Spring Boot 기본 설정).
+     */
+    public record NaverLocalSearchResult(
+            int total,
+            int start,
+            int display,
+            List<Item> items
+    ) {
+
+        public record Item(
+                String title,
+                String link,
+                String category,
+                String description,
+                String telephone,
+                String address,
+                String roadAddress,
+                String mapx,
+                String mapy
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/jjimkong_backend/api/service/map/impl/MapServiceImpl.java
+++ b/src/main/java/com/jjimkong_backend/api/service/map/impl/MapServiceImpl.java
@@ -1,0 +1,49 @@
+package com.jjimkong_backend.api.service.map.impl;
+
+import com.jjimkong_backend.api.service.map.MapService;
+import com.jjimkong_backend.api.service.map.dto.request.PlaceSearchRequest;
+import com.jjimkong_backend.api.service.map.dto.response.PlaceSearchResponse;
+import com.jjimkong_backend.api.service.map.dto.response.PlaceSearchResponse.NaverLocalSearchResult;
+import com.jjimkong_backend.global.response.exception.BadRequestException;
+import com.jjimkong_backend.global.response.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class MapServiceImpl implements MapService {
+
+    /** 네이버 지역 검색 API 경로 */
+    private static final String LOCAL_SEARCH_PATH = "/v1/search/local.json";
+
+    private final RestClient naverSearchRestClient;
+
+    @Override
+    public PlaceSearchResponse searchPlaces(PlaceSearchRequest request) {
+        NaverLocalSearchResult result = requestLocalSearch(request);
+        return PlaceSearchResponse.from(result);
+    }
+
+    private NaverLocalSearchResult requestLocalSearch(PlaceSearchRequest request) {
+        try {
+            return naverSearchRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(LOCAL_SEARCH_PATH)
+                            .queryParam("query", request.query())
+                            .queryParam("display", request.displayOrDefault())
+                            .queryParam("sort", request.sortOrDefault())
+                            .build())
+                    .retrieve()
+                    .body(NaverLocalSearchResult.class);
+        } catch (RestClientException e) {
+            log.error("네이버 지역 검색 API 호출 실패 - query: {}, message: {}", request.query(), e.getMessage());
+            throw new BadRequestException(ExceptionCode.NAVER_SEARCH_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/jjimkong_backend/global/config/naver/NaverSearchClientConfig.java
+++ b/src/main/java/com/jjimkong_backend/global/config/naver/NaverSearchClientConfig.java
@@ -1,0 +1,30 @@
+package com.jjimkong_backend.global.config.naver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 네이버 검색 API 호출 전용 {@link RestClient} 빈 설정.
+ * <p>
+ * 인증 헤더({@code X-Naver-Client-Id}, {@code X-Naver-Client-Secret})를
+ * 기본 헤더로 주입해 둔다.
+ */
+@Configuration
+@EnableConfigurationProperties(NaverSearchProperties.class)
+@RequiredArgsConstructor
+public class NaverSearchClientConfig {
+
+    private final NaverSearchProperties properties;
+
+    @Bean
+    public RestClient naverSearchRestClient() {
+        return RestClient.builder()
+                .baseUrl(properties.baseUrl())
+                .defaultHeader("X-Naver-Client-Id", properties.clientId())
+                .defaultHeader("X-Naver-Client-Secret", properties.clientSecret())
+                .build();
+    }
+}

--- a/src/main/java/com/jjimkong_backend/global/config/naver/NaverSearchProperties.java
+++ b/src/main/java/com/jjimkong_backend/global/config/naver/NaverSearchProperties.java
@@ -1,0 +1,31 @@
+package com.jjimkong_backend.global.config.naver;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 네이버 검색 API 설정값.
+ * <p>
+ * 실제 값은 환경변수로 관리한다. {@code application.yml}에서 아래와 같이 매핑한다.
+ * <pre>
+ * naver:
+ *   search:
+ *     base-url: https://openapi.naver.com
+ *     client-id: ${NAVER_SEARCH_CLIENT_ID}
+ *     client-secret: ${NAVER_SEARCH_CLIENT_SECRET}
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "naver.search")
+public record NaverSearchProperties(
+        String baseUrl,
+        String clientId,
+        String clientSecret
+) {
+
+    private static final String DEFAULT_BASE_URL = "https://openapi.naver.com";
+
+    public NaverSearchProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            baseUrl = DEFAULT_BASE_URL;
+        }
+    }
+}

--- a/src/main/java/com/jjimkong_backend/global/response/exception/ExceptionCode.java
+++ b/src/main/java/com/jjimkong_backend/global/response/exception/ExceptionCode.java
@@ -20,7 +20,10 @@ public enum ExceptionCode {
 
     // Redis
     REDIS_DATA_SIZE_EXCEEDED_ERROR("E_REDIS", BAD_REQUEST, "Redis에 저장할 데이터 크기가 허용치를 초과했습니다."),
-    REDIS_DATA_DELETE_ERROR("E_REDIS", BAD_REQUEST, "Redis에 저장된 데이터 삭제 중 오류가 발생했습니다.");
+    REDIS_DATA_DELETE_ERROR("E_REDIS", BAD_REQUEST, "Redis에 저장된 데이터 삭제 중 오류가 발생했습니다."),
+
+    // Map (네이버 지도/검색)
+    NAVER_SEARCH_API_ERROR("E_MAP_001", BAD_GATEWAY, "네이버 검색 API 호출 중 오류가 발생했습니다.");
 
     private final String code;
     private String message;


### PR DESCRIPTION
## 📢 기능 설명
네이버 지역 검색 API를 이용한 장소(맛집) 키워드 검색 기능을 추가했습니다.

- `GET /api/v1/maps/places?query=&display=&sort=` 엔드포인트 (인증 필요)
- `RestClient`로 네이버 지역 검색 API 호출, 인증 헤더(`X-Naver-Client-Id`/`X-Naver-Client-Secret`)는 클라이언트 기본 헤더로 자동 주입
- `client-id`/`secret`은 환경변수(`NAVER_SEARCH_CLIENT_ID`/`NAVER_SEARCH_CLIENT_SECRET`)로 관리 (`@ConfigurationProperties`)
- 응답은 HTML 태그 제거 + `mapx`/`mapy` → WGS84 경·위도 변환 후 반환
- 호출 실패 시 `ExceptionCode.NAVER_SEARCH_API_ERROR`(E_MAP_001, 502)

레이어 규약(Controller → Service interface → Impl → DTO record)과 `ApiResponse`/`ExceptionCode` 컨벤션을 따랐습니다.

## 연결된 issue
- close #12
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?

📣 **To Reviewers**
---
- `application.yml`(로컬 전용)에 `naver.search.*` 설정과 환경변수가 필요합니다.
- 좌표 변환은 `mapx/mapy = WGS84 × 10^7` 가정으로 구현했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)